### PR TITLE
Adding compression plugin for gzip and brotli files during build. only mweb

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -36,6 +36,7 @@ const ModuleNotFoundPlugin = require('react-dev-utils/ModuleNotFoundPlugin');
 const ForkTsCheckerWebpackPlugin = require('react-dev-utils/ForkTsCheckerWebpackPlugin');
 const typescriptFormatter = require('react-dev-utils/typescriptFormatter');
 const eslint = require('eslint');
+const CompressionPlugin = require('compression-webpack-plugin');
 // @remove-on-eject-begin
 const getCacheIdentifier = require('react-dev-utils/getCacheIdentifier');
 // @remove-on-eject-end
@@ -592,6 +593,21 @@ module.exports = function(webpackEnv) {
       ],
     },
     plugins: [
+      isMWeb && new CompressionPlugin({
+        filename: '[path].gz[query]',
+        algorithm: 'gzip',
+        test: /\.js$|\.css$|\.html$/,
+        threshold: 2048,
+        minRatio: 0.8,
+      }),
+      isMWeb && new CompressionPlugin({
+        filename: '[path].br[query]',
+        algorithm: 'brotliCompress',
+        test: /\.(js|css|html|svg)$/,
+        compressionOptions: { level: 11 },
+        threshold: 2048,
+        minRatio: 0.8,
+      }),
       // Generates an `index.html` file with the <script> injected.
       new HtmlWebpackPlugin(
         Object.assign(

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -82,7 +82,8 @@
     "webpack-hot-middleware": "^2.24.3",
     "webpack-manifest-plugin": "2.0.4",
     "workbox-webpack-plugin": "4.2.0",
-    "write-assets-webpack-plugin": "^1.0.5"
+    "write-assets-webpack-plugin": "^1.0.5",
+    "compression-webpack-plugin": "3.1.0"
   },
   "devDependencies": {
     "react": "^16.8.4",


### PR DESCRIPTION
During build time Webpack will generate gZipped and Brotli compressed versions of static files. (only for PWA for now)

Base PR: https://github.com/tajawal/web-mobile/pull/2023
